### PR TITLE
In region check fix.

### DIFF
--- a/Model/RegionType/CircleType.cs
+++ b/Model/RegionType/CircleType.cs
@@ -50,7 +50,7 @@ namespace RocketRegions.Model.RegionType
 
         public override bool IsInRegion(SerializablePosition p)
         {
-            return GetDistance(p) <= Radius;
+            return GetDistanceToCenter(p) <= Radius;
         }
 
         public override bool OnRedefine(IRocketPlayer player, string[] args)


### PR DESCRIPTION
This fixes the issue that doubles the apparent radius of the region. The IsInRegion was checking if you were radius away from the edge of the region, not the center.
