### PR TITLE
Fixed flag issue

### DIFF
--- a/RegionsPlugin.cs
+++ b/RegionsPlugin.cs
@@ -144,8 +144,18 @@ namespace RocketRegions
             var currentRegion = GetRegionAt(StRegion.structures[Index].point);
             if (currentRegion == null)
                 return;
-            if (currentRegion.Flags.Exists(fg => fg.Name == "NoDestroy") && !R.Permissions.HasPermission(new RocketPlayer(instigatorSteamID.m_SteamID.ToString()), Configuration.Instance.NoDestroyIgnorePermission) && !Configuration.Instance.NoDestroyIgnoredItems.Exists(k => k == StRegion.structures[Index].structure.id))
+            if (currentRegion.Flags.Exists(fg => fg.Name.Equals("NoDestroy", StringComparison.OrdinalIgnoreCase)))
+            {
+                UnturnedPlayer dealer = UnturnedPlayer.FromCSteamID(instigatorSteamID);
+
+                if (dealer == null)
+                    return;
+                
+                if (dealer.HasPermission(Configuration.Instance.NoDestroyIgnorePermission) || Configuration.Instance.NoDestroyIgnoredItems.Exists(k => k == StRegion.structures[Index].structure.id))
+                    return;
+
                 shouldAllow = false;
+            }
             else
                 return;
         }
@@ -156,8 +166,18 @@ namespace RocketRegions
             var currentRegion = GetRegionAt(BarRegion.barricades[Index].point);
             if (currentRegion == null)
                 return;
-            if (currentRegion.Flags.Exists(fg => fg.Name == "NoDestroy") && !R.Permissions.HasPermission(new RocketPlayer(instigatorSteamID.m_SteamID.ToString()), Configuration.Instance.NoDestroyIgnorePermission) && !Configuration.Instance.NoDestroyIgnoredItems.Exists(k => k == BarRegion.barricades[Index].barricade.id))
+            if (currentRegion.Flags.Exists(fg => fg.Name.Equals("NoDestroy", StringComparison.OrdinalIgnoreCase)))
+            {
+                UnturnedPlayer dealer = UnturnedPlayer.FromCSteamID(instigatorSteamID);
+
+                if (dealer == null)
+                    return;
+                
+                if (dealer.HasPermission(Configuration.Instance.NoDestroyIgnorePermission) || Configuration.Instance.NoDestroyIgnoredItems.Exists(k => k == BarRegion.barricades[Index].barricade.id))
+                    return;
+
                 shouldAllow = false;
+            }
             else
                 return;
         }


### PR DESCRIPTION
`currentRegion.Flags.Exists(fg => fg.Name == "NoDestroy")` wasn't a correct check, so if the flag name was `nodestroy`, it would not continue and prevent the damage. Changed for the more correct `currentRegion.Flags.Exists(fg => fg.Name.Equals("NoDestroy", StringComparison.OrdinalIgnoreCase))`